### PR TITLE
Revert "[mysql][refactor] Enable to pass query and args to Exec function"

### DIFF
--- a/internal/mysql/mysql.go
+++ b/internal/mysql/mysql.go
@@ -5,8 +5,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const driverName = "mysql"
-
 type MySQLConfig struct {
 	AdminUser     string
 	AdminPassword string
@@ -14,7 +12,7 @@ type MySQLConfig struct {
 }
 
 type MySQLClient interface {
-	Exec(query string, args ...interface{}) error
+	Exec(query string) error
 	Ping() error
 	Close()
 }
@@ -30,7 +28,7 @@ func NewFakeMySQLClient(cfg MySQLConfig) MySQLClient {
 	return &fakeMysqlCLient{}
 }
 
-func (mc fakeMysqlCLient) Exec(query string, args ...interface{}) error {
+func (mc fakeMysqlCLient) Exec(query string) error {
 	return nil
 }
 
@@ -44,18 +42,14 @@ func (mc fakeMysqlCLient) Close() {
 type MySQLClientFactory func(cfg MySQLConfig) MySQLClient
 
 func NewMySQLClient(config MySQLConfig) MySQLClient {
-	dataSourceName := config.AdminUser+":"+config.AdminPassword+"@tcp("+config.Host+":3306)/"
-	db, _ := sql.Open(
-		driverName,
-		dataSourceName,
-	)
+	db, _ := sql.Open("mysql", config.AdminUser+":"+config.AdminPassword+"@tcp("+config.Host+":3306)/")
 	// TODO error handling
 	return &mysqlClient{db: db}
 }
 
-func (mc mysqlClient) Exec(query string, args ...interface{}) error {
+func (mc mysqlClient) Exec(query string) error {
 	var log = logf.Log.WithName("mysql")
-	_, err := mc.db.Exec(query, args)
+	_, err := mc.db.Exec(query)
 	if err != nil {
 		log.Error(err, "Failed to execute query", query)
 		return err


### PR DESCRIPTION
Reverts nakamasato/mysql-operator#57

```
go run ./main.go
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.metrics      metrics server is starting to listen    {"addr": ":8080"}
2021-11-08T08:36:06.452+0900    INFO    setup   starting manager
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.manager      starting metrics server {"path": "/metrics"}
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.manager.controller.mysqluser Starting EventSource    {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser", "source": "kind source: /, Kind="}
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.manager.controller.mysqluser Starting Controller     {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser"}
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.manager.controller.mysql     Starting EventSource    {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQL", "source": "kind source: /, Kind="}
2021-11-08T08:36:06.452+0900    INFO    controller-runtime.manager.controller.mysql     Starting Controller     {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQL"}
2021-11-08T08:36:06.556+0900    INFO    controller-runtime.manager.controller.mysqluser Starting workers        {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser", "worker count": 1}
2021-11-08T08:36:06.556+0900    INFO    controller-runtime.manager.controller.mysql     Starting workers        {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQL", "worker count": 1}
2021-11-08T08:36:09.364+0900    INFO    controller-runtime.manager.controller.mysqluser Fetch MySQLUser instance. MySQLUser resource found.      {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser", "name": "nakamasato", "namespace": "default", "name": "nakamasato", "mysqlUser.Namespace": "default"}
2021-11-08T08:36:09.364+0900    INFO    controller-runtime.manager.controller.mysqluser Fetched MySQL instance. {"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser", "name": "nakamasato", "namespace": "default"}
2021-11-08T08:36:09.475+0900    INFO    controller-runtime.manager.controller.mysqluser Create MySQL user if not.{"reconciler group": "mysql.nakamasato.com", "reconciler kind": "MySQLUser", "name": "nakamasato", "namespace": "default", "name": "nakamasato", "mysqlUser.Namespace": "default"}
2021-11-08T08:36:09.475+0900    DPANIC  mysql   odd number of arguments passed as key-value pairs for logging   {"ignored key": "CREATE USER IF NOT EXISTS 'nakamasato'@'%' IDENTIFIED BY 'cxZowir3FSJejBA3';"}
github.com/nakamasato/mysql-operator/internal/mysql.mysqlClient.Exec
        /Users/masato-naka/repos/nakamasato/mysql-operator/internal/mysql/mysql.go:60
github.com/nakamasato/mysql-operator/controllers.(*MySQLUserReconciler).Reconcile
        /Users/masato-naka/repos/nakamasato/mysql-operator/controllers/mysqluser_controller.go:162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:214
panic: odd number of arguments passed as key-value pairs for logging

goroutine 349 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc000662180, {0xc0005c2580, 0x1, 0x1})
        /Users/masato-naka/go/pkg/mod/go.uber.org/zap@v1.17.0/zapcore/entry.go:234 +0x499
go.uber.org/zap.(*Logger).DPanic(0x22930f8, {0x22e19b0, 0x2069440}, {0xc0005c2580, 0x1, 0x1})
        /Users/masato-naka/go/pkg/mod/go.uber.org/zap@v1.17.0/logger.go:217 +0x59
github.com/go-logr/zapr.handleFields(0xc0000b7130, {0xc00053e500, 0x1, 0x17}, {0xc0005c2500, 0x1, 0x100e394})
        /Users/masato-naka/go/pkg/mod/github.com/go-logr/zapr@v0.4.0/zapr.go:100 +0x535
github.com/go-logr/zapr.(*zapLogger).Error(0xc00053e4c0, {0x2479580, 0xc00053e4f0}, {0x22a0955, 0x4c}, {0xc00053e500, 0x1, 0x1})
        /Users/masato-naka/go/pkg/mod/github.com/go-logr/zapr@v0.4.0/zapr.go:133 +0x1eb
github.com/nakamasato/mysql-operator/internal/mysql.mysqlClient.Exec({0x6}, {0xc000bac460, 0x4c}, {0x0, 0x0, 0x0})
        /Users/masato-naka/repos/nakamasato/mysql-operator/internal/mysql/mysql.go:60 +0x175
github.com/nakamasato/mysql-operator/controllers.(*MySQLUserReconciler).Reconcile(0xc0002e9440, {0x24a4838, 0xc000c2ffb0}, {{{0xc0002b7169, 0x7}, {0xc0002b7140, 0xa}}})
        /Users/masato-naka/repos/nakamasato/mysql-operator/controllers/mysqluser_controller.go:162 +0xd99
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004bafa0, {0x24a4790, 0xc0005c2880}, {0x212e620, 0xc0002ae5a0})
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:298 +0x303
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004bafa0, {0x24a4790, 0xc0005c2880})
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:214 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /Users/masato-naka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:210 +0x354
exit status 2
make: *** [run] Error 1
```

Close #59 