### PR TITLE
[mysql_controller] simplify mysql controller with indexer and ListOptions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set up
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: 1.16
 
       - uses: actions/checkout@master
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,12 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set up
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
-
-      - name: install ginkgo
-        run: go get -u github.com/onsi/ginkgo/ginkgo
+          go-version: 1.16
 
       - name: install skaffold # TODO: #69 Enable to install skaffold in e2e
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set up
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: 1.16
 
       - name: install ginkgo
         run: go get -u github.com/onsi/ginkgo/ginkgo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: install ginkgo
-        run: go get -u github.com/onsi/ginkgo/ginkgo
-
       - uses: actions/checkout@master
 
       - run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,23 @@ Prerequisite:
 
 - [kind](https://kind.sigs.k8s.io/): local Kubernetes cluster
 - [krew](https://krew.sigs.k8s.io/): kubectl plugin manager
+    ```bash
+    (
+      set -x; cd "$(mktemp -d)" &&
+      OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+      ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+      KREW="krew-${OS}_${ARCH}" &&
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+      tar zxvf "${KREW}.tar.gz" &&
+      ./"${KREW}" install krew
+    )
+    ```
+    Add `export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"` to `~/.bashrc` or `~/.zshrc`
 - [kuttl](https://kuttl.dev/): The KUbernetes Test TooL (kuttl)
+    ```
+    brew tap kudobuilder/tap
+    brew install kuttl-cli
+    ```
 
 Test scenario:
 1. MySQL `Deployment` and `Service`. -> Assert MySQL replica is 1.

--- a/Makefile
+++ b/Makefile
@@ -215,5 +215,5 @@ e2e-with-kuttl:
 	kubectl kuttl test
 
 .PHONY: e2e-with-ginkgo
-e2e-with-ginkgo:
+e2e-with-ginkgo: ginkgo
 	$(GINKGO) e2e

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ define go-get-tool
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
-go mod init tmp ;\
+go mod init github.com/nakamasato/mysql-operator ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ define go-get-tool
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
-go mod init github.com/nakamasato/mysql-operator ;\
+go mod init tmp ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" ginkgo -cover -coverprofile cover.out -covermode=atomic -skipPackage=e2e ./...
+test: ginkgo manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) -cover -coverprofile cover.out -covermode=atomic -skipPackage=e2e ./...
 
 ##@ Build
 
@@ -132,7 +132,11 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+GINKGO = $(shell pwd)/bin/ginkgo
+ginkgo:
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/ginkgo@latest)
+
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -141,7 +145,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -216,4 +216,4 @@ e2e-with-kuttl:
 
 .PHONY: e2e-with-ginkgo
 e2e-with-ginkgo:
-	ginkgo e2e
+	$(GINKGO) e2e

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "50...100"
+  range: "30...100"
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,11 +4,13 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "30...100"
+  range: "50...100"
   status:
     project:
       default:
         target: 0%
-
+    patch:
+      default:
+        target: 0%
 ignore:
   - e2e

--- a/controllers/mysql_controller.go
+++ b/controllers/mysql_controller.go
@@ -105,11 +105,5 @@ func (r *MySQLReconciler) countReferencesByMySQLUser(ctx context.Context, log lo
 	if err != nil {
 		return 0, err
 	}
-	mysqlUserCount := 0
-	for _, mysqlUser := range mysqlUserList.Items {
-		if mysqlUser.Spec.MysqlName == mysql.Name {
-			mysqlUserCount++
-		}
-	}
-	return mysqlUserCount, nil
+	return len(mysqlUserList.Items), nil
 }

--- a/controllers/mysql_controller.go
+++ b/controllers/mysql_controller.go
@@ -100,13 +100,16 @@ func (r *MySQLReconciler) countReferencesByMySQLUser(ctx context.Context, log lo
 	// 1. Get the referenced MySQLUser instances.
 	// 2. Return the number of referencing MySQLUser.
 	mysqlUserList := &mysqlv1alpha1.MySQLUserList{}
-	opts := []client.ListOption{
-		client.MatchingFields{"spec.mysqlName": mysql.Name},
-	}
-	err := r.List(ctx, mysqlUserList, opts...)
+	err := r.List(ctx, mysqlUserList, client.MatchingFields{"spec.mysqlName": mysql.Name})
 
 	if err != nil {
 		return 0, err
 	}
-	return len(mysqlUserList.Items), nil
+	mysqlUserCount := 0
+	for _, mysqlUser := range mysqlUserList.Items {
+		if mysqlUser.Spec.MysqlName == mysql.Name {
+			mysqlUserCount++
+		}
+	}
+	return mysqlUserCount, nil
 }

--- a/controllers/mysql_controller.go
+++ b/controllers/mysql_controller.go
@@ -100,16 +100,13 @@ func (r *MySQLReconciler) countReferencesByMySQLUser(ctx context.Context, log lo
 	// 1. Get the referenced MySQLUser instances.
 	// 2. Return the number of referencing MySQLUser.
 	mysqlUserList := &mysqlv1alpha1.MySQLUserList{}
-	err := r.List(ctx, mysqlUserList)
-	mysqlUserCount := 0
-	if err != nil {
-		return mysqlUserCount, err
+	opts := []client.ListOption{
+		client.MatchingFields{"spec.mysqlName": mysql.Name},
 	}
+	err := r.List(ctx, mysqlUserList, opts...)
 
-	for _, mysqlUser := range mysqlUserList.Items {
-		if mysqlUser.Spec.MysqlName == mysql.Name {
-			mysqlUserCount++
-		}
+	if err != nil {
+		return 0, err
 	}
-	return mysqlUserCount, nil
+	return len(mysqlUserList.Items), nil
 }


### PR DESCRIPTION
## Changes
- Use `client.MatchingFields`

    ```go
    r.List(ctx, mysqlUserList, client.MatchingFields{"spec.mysqlName": mysql.Name})`
    ```
- Set Index for `spec.mysqlName` in `main.go` and `mysql_controller_test.go`

  ```go
	  cache := mgr.GetCache()
	  indexFunc := func(obj client.Object) []string {
		  return []string{obj.(*mysqlv1alpha1.MySQLUser).Spec.MysqlName}
	  }
	  if err := cache.IndexField(context.TODO(), &mysqlv1alpha1.MySQLUser{}, "spec.mysqlName", indexFunc); err != nil {
		  panic(err)
	  }
  ```
- Use `actions/setup-go@v3` instead of v2 in GitHub Actions
- Change the install command from `go get` to `go install` in `Makefile`
- Upgrade kustomize to v4.5.2 to fix (ref: https://github.com/kubernetes-sigs/kustomize/issues/3618)

  ```
  go: creating new go.mod: module tmp
  Downloading sigs.k8s.io/kustomize/kustomize/v3@v3.8.7
  go: sigs.k8s.io/kustomize/kustomize/v3@v3.8.7 (in sigs.k8s.io/kustomize/kustomize/v3@v3.8.7):
          The go.mod file for the module providing named packages contains one or
          more exclude directives. It must not contain directives that would cause
          it to be interpreted differently than if it were the main module.
  make: *** [kustomize] Error 1
  ```


## Indexing
Indexes may be added to caches using a FieldIndexer. This allows you to easily and efficiently look up objects with certain properties. You can then make use of the index by specifying a field selector on calls to List on the Reader corresponding to the given Cache.

- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/client#hdr-Indexing
- https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/example_test.go
- https://stackoverflow.com/questions/57083221/list-custom-resources-from-caching-client-with-custom-fieldselector
- https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#example-FieldIndexer-SecretName
