### PR TITLE
chore: revert "chore(deps): update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
           cat cover.out >> coverage.txt
 
       - name: codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reverts nakamasato/mysql-operator#266

v4 seems to be removed

https://github.com/nakamasato/mysql-operator/actions/runs/6207105467?pr=260

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```