### PR TITLE
Add grant option to mysqluser

### DIFF
--- a/api/v1alpha1/mysqluser_types.go
+++ b/api/v1alpha1/mysqluser_types.go
@@ -20,6 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Grant defines the privileges and the resource for a MySQL user
+type Grant struct {
+	// Privileges for the MySQL user
+	Privileges string `json:"privileges"`
+
+	// Resource on which the privileges are applied
+	On string `json:"on"`
+}
+
 // MySQLUserSpec defines the desired state of MySQLUser
 type MySQLUserSpec struct {
 
@@ -31,6 +40,9 @@ type MySQLUserSpec struct {
 
 	// MySQL hostname for MySQL account
 	Host string `json:"host"`
+
+	// Grants for the MySQL user
+	Grants []Grant `json:"grants,omitempty"`
 }
 
 // MySQLUserStatus defines the observed state of MySQLUser

--- a/config/crd/bases/mysql.nakamasato.com_mysqlusers.yaml
+++ b/config/crd/bases/mysql.nakamasato.com_mysqlusers.yaml
@@ -59,6 +59,16 @@ spec:
                 description: MySQL (CRD) name to reference to, which decides the destination
                   MySQL server
                 type: string
+              grants:
+                description: Grants for the MySQL user
+                items:
+                  type: object
+                  properties:
+                    privileges:
+                      type: string
+                    on:
+                      type: string
+                type: array
             required:
             - mysqlName
             type: object

--- a/config/samples-on-k8s/mysql_v1alpha1_mysqluser.yaml
+++ b/config/samples-on-k8s/mysql_v1alpha1_mysqluser.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   mysqlName: mysql-sample
   host: '%'
+  grants:
+    - privileges: "ALL"
+      on: "mysql-sample-db.*"


### PR DESCRIPTION
This commit allow to define grant permissions to mysqluser.
Example:
apiVersion: mysql.nakamasato.com/v1alpha1
kind: MySQLUser
metadata:
  name: sample-user
spec:
  mysqlName: mysql-sample
  host: '%'
  grants:
    - privileges: "ALL"
      on: "mysql-sample-db1.*"
    - privileges: "SELECT, INSERT, UPDATE"
      on: "mysql-sample-db2.*"