### PR TITLE
fix: rename --cloud-secret-manager to --admin-user-secret-type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ golangci-lint run ./...
     ```
     make install run
     ```
+
+    if you need to specify args you can run `go run ./cmd/main.go --admin-user-secret-type=k8s --k8s-secret-namespace=default` after `make install`
+
 1. Apply sample resources.
     ```
     kubectl apply -k config/samples
@@ -233,7 +236,7 @@ docker rm -f $(docker ps | grep mysql | head -1 |awk '{print $1}')
 1. Install and run operator
     ```
     make install
-    PRJECT_ID=$PROJECT_ID go run main.go --cloud-secret-manager gcp
+    PRJECT_ID=$PROJECT_ID go run main.go --admin-user-secret-type gcp
     ```
 1. Create custom resources
     ```

--- a/README.md
+++ b/README.md
@@ -187,6 +187,46 @@ anager.secretAccessor` permission
 
 [Read credentials from GCP SecretManager](docs/usage/gcp-secretmanager.md)
 
+
+## With k8s Secret Manager
+
+Instead of writing raw password in `MySQL.Spec.AdminPassword`, you can get the password for root user from an external secret manager (e.g. K8s)
+
+1. Create Kubernetes Secret.
+    ```
+    kubectl create secret generic mysql-user --from-literal=key=root
+    kubectl create secret generic mysql-password --from-literal=key=password
+    ```
+
+1. Install mysql-operator with `--set adminUserSecretType=k8s --set adminUserSecretNamespace=default`
+    ```
+    helm repo add nakamasato https://nakamasato.github.io/helm-charts
+    helm repo update
+    helm install mysql-operator nakamasato/mysql-operator --set adminUserSecretType=k8s --set adminUserSecretNamespace=default
+    ```
+1. You can specify `type: k8s` for `adminUser` and `adminPassword`.
+
+    ```yaml
+    apiVersion: mysql.nakamasato.com/v1alpha1
+    kind: MySQL
+    metadata:
+      name: mysql-sample
+    spec:
+      host: mysql.default # need to include namespace if you use Kubernetes Service as an endpoint.
+      adminUser:
+        name: mysql-user # secret name in SecretManager
+        type: k8s
+      adminPassword:
+        name: mysql-password # secret name in SecretManager
+        type: k8s
+    ```
+
+    Example: (you need to run `kubectl apply -k config/mysql`)
+    ```
+    kubectl apply -k config/samples-on-k8s-with-k8s-secret
+    ```
+
+
 ## Exposed Metrics
 
 - `mysql_user_created_total`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,9 +67,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&adminUserSecretType, "cloud-secret-manager", "",
-		"The cloud secret manager to get credentials from. "+
-			"Currently, only support gcp")
+	flag.StringVar(&adminUserSecretType, "admin-user-secret-type", "",
+		"The secret manager to get credentials from. "+
+			"Currently, support raw, gcp, and k8s. ")
 	flag.StringVar(&projectId, "gcp-project-id", "",
 		"GCP project id. Set this value to use adminUserSecretType=gcp. "+
 			"Also can be set by environment variable PROJECT_ID."+

--- a/config/default/manager_gcp_sa_secret_patch.yaml
+++ b/config/default/manager_gcp_sa_secret_patch.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 64Mi
         - name: manager
           args:
-            - "--cloud-secret-manager=gcp"
+            - "--admin-user-secret-type=gcp"
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=127.0.0.1:8080"
             - "--leader-elect"

--- a/config/mysql/kustomization.yaml
+++ b/config/mysql/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - mysql-deployment.yaml
   - mysql-service.yaml
   - mysql-service-nodeport.yaml
+  # - mysql-secret.yaml

--- a/config/mysql/mysql-secret.yaml
+++ b/config/mysql/mysql-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  key: cm9vdA==
+kind: Secret
+metadata:
+  name: mysql-user
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: cGFzc3dvcmQ=
+kind: Secret
+metadata:
+  name: mysql-password
+type: Opaque

--- a/config/samples-on-k8s-with-k8s-secret/kustomization.yaml
+++ b/config/samples-on-k8s-with-k8s-secret/kustomization.yaml
@@ -1,0 +1,6 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- mysql_v1alpha1_mysqluser.yaml
+- mysql_v1alpha1_mysql.yaml
+- mysql_v1alpha1_mysqldb.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysql.yaml
+++ b/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysql.yaml
@@ -1,0 +1,12 @@
+apiVersion: mysql.nakamasato.com/v1alpha1
+kind: MySQL
+metadata:
+  name: mysql-sample
+spec:
+  host: "mysql.default"
+  adminUser:
+    name: mysql-user
+    type: k8s
+  adminPassword: # stored in GCP SecretMamanger
+    name: mysql-password
+    type: k8s

--- a/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysqldb.yaml
+++ b/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysqldb.yaml
@@ -1,0 +1,7 @@
+apiVersion: mysql.nakamasato.com/v1alpha1
+kind: MySQLDB
+metadata:
+  name: sample-db # this is not a name for MySQL database but just a Kubernetes object name
+spec:
+  dbName: sample_db # this is MySQL database name
+  mysqlName: mysql-sample

--- a/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysqluser.yaml
+++ b/config/samples-on-k8s-with-k8s-secret/mysql_v1alpha1_mysqluser.yaml
@@ -1,0 +1,6 @@
+apiVersion: mysql.nakamasato.com/v1alpha1
+kind: MySQLUser
+metadata:
+  name: sample-user
+spec:
+  mysqlName: mysql-sample


### PR DESCRIPTION
# why

To make it consistent with the variable name `AdminUserSecretType`

## What

- Rename --cloud-secret-manager to --admin-user-secret-type
- Update docs
